### PR TITLE
Add `deleteUserFunction` E2 function

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_vexdocs.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_vexdocs.lua
@@ -82,6 +82,7 @@ desc("getConstants()","Returns a table containing all registered E2 constants (c
 desc("getUserFunctionInfo(n)","Returns a table containing useful information about all user-defined functions. This function can operate differently, the `mode` argument controls how the output table will be structured. Use _UDF_* constant as `mode` argument")
 desc("getBuiltinFuncInfo(s)","Returns a table containing information about the builtin (non-UDF) E2 functions. Either use \"*\" as a `funcName` to get infos for all, or specify a function name/signature (e.g. \"selfDestruct\")")
 desc("getTypeInfo()","Returns a table containing E2 types information (type ID is used as table key, and type name as the table value)")
+desc("deleteUserFunction(s)","Attempts to delete a user-defined function from this E2's context. You must specify a full signature (i.e. \"myFunc(e:av)\").")
 
 --[[
  _    __ ____   __  ___            __   ______                                 __   _  __     _  __ _  __

--- a/lua/entities/gmod_wire_expression2/core/custom/sv_selfaware2.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/sv_selfaware2.lua
@@ -268,3 +268,17 @@ e2function table getTypeInfo()
     end
     return luaTableToE2(ret, 0) -- Convert into a compatible E2 table without array optimization.
 end
+
+--===========================================================================================================================
+
+e2cost(3)
+
+-- Attempts to delete a user-defined function from this E2's context. You must specify a full signature (i.e. "myFunc(e:av)").
+e2function number deleteUserFunction(string funcName)
+    local exists = self.funcs[funcName]
+    if exists then
+        self.funcs[funcName] = nil
+        return 1
+    end
+    return 0
+end


### PR DESCRIPTION
I forgot to add this one... So, here it is, a pretty quick one.

* Attempts to delete a user-defined function from E2's runtime context. You must specify a full signature (i.e. `"myFunc(e:av)"`).

<details>
<summary><b>Test code</b> [✔️] (click to expand)</summary>

```golo

local GoOnce = "goOnce()"

print("1. defined: " + (defined(GoOnce) ? "Yes! [_should_not_see_this_]" : "Ok. Undefined."))

print("2. deleteUserFunction: " + (deleteUserFunction(GoOnce) ? "Yes! [_should_not_see_this_]" : "Ok. Undefined."))

function goOnce()
{
    print("Please wait... (Doing some work...)")
    function goOnce(){} # Done with work... So let's redefine this UDF as empty.
}

goOnce()

print("3. defined: " + (defined(GoOnce) ? "Yes." : "Failed! [_should_not_see_this_]"))

print("4. deleteUserFunction: " + (deleteUserFunction(GoOnce) ? "Yes. Deleted." : "Failed! [_should_not_see_this_]"))

print("5. deleteUserFunction: " + (deleteUserFunction(GoOnce) ? "Failed! [_should_not_see_this_]" : "Ok. Undefined."))

print("6. defined: " + (defined(GoOnce) ? "Yes! [_should_not_see_this_]" : "Ok. Undefined."))

# goOnce() # This should throw (if uncommented).
# "goOnce"() # This should throw as well (if uncommented).

local TryResult = try(GoOnce)
print("[try result]") printTable(TryResult)
assert(!TryResult[1, number], GoOnce + " function is still defined?!?! [_should_not_see_this_]")
```

<b>Output</b>:
```
1. defined: Ok. Undefined.
2. deleteUserFunction: Ok. Undefined.
Please wait... (Doing some work...)
3. defined: Yes.
4. deleteUserFunction: Yes. Deleted.
5. deleteUserFunction: Ok. Undefined.
6. defined: Ok. Undefined.
[try result]
1	=	0
2	=	Try was called with undefined function [goOnce()]
```

</details>

Working great, smash merge 😄