### PR TITLE
The Coroutine Overhaul

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/Tests/Coroutines.txt
+++ b/lua/entities/gmod_wire_expression2/core/custom/Tests/Coroutines.txt
@@ -4,29 +4,46 @@
 #[
     What this checks:
         Returning args table
+        
         Passing args table
+        
         Stack overflow threshold
+        
         Anti-Repeated "Coroutine Error: " in Coroutine Errors
-    What this doesn't check:
-        Coroutines that last several ticks (Use https://github.com/Vurv78/VExtensions/discussions/29)
+        
         Coroutines affecting the main thread (https://github.com/Vurv78/VExtensions/issues/18)
+        
+        Coroutines sharing memory / Tables with the main thread
+             
+    What this doesn't check:
+        Coroutines that last several ticks (Use https://github.com/Vurv78/VExtensions/discussions/29 instead.)
 ]#
 
+COROUTINE_STACK_MAX = 51
+
+I = 0
 function void stack_overflow(){
     Co = coroutine("stack_overflow")
+    I++
+    if(I>COROUTINE_STACK_MAX){ error(" stack_overflow test failed. "), return } # If the stack overflow threshold somehow fails to trigger, error it ourselves.
     Co:resume()
 }
 
-assert( try("stack_overflow")[2,string] == "Coroutine Error: Coroutine stack overflow", "stack_overflow test failed" )
+assert(try("stack_overflow")[1,number]==0,"stack_overflow test failed")
 
 The_Table = table("br",2,3) # For some reason this can't be local
 function table return_table(){
+    print("Return table test!")
+    print("ret",The_Table[1,string])
+    The_Table[2,number] = 420
     return The_Table
 }
 
 # You can't equate the two tables themselves, because for now we copy the actual scopes instead of having
 # 'real' shared tables.
+
 assert(The_Table[1,string] == coroutine("return_table"):resume()[1,string], "return_table test failed")
+print(The_Table[2,number])
 
 The_Number = 12040124 # Same as L12
 function table pass_args(T:table){
@@ -36,14 +53,24 @@ function table pass_args(T:table){
 
 coroutine("pass_args",table(The_Number,2,3)):resume()
 
+Shared = table(5,4,2)
+function table memory_shared(){
+    Shared[2,number] = 1000000000
+    return Shared    
+}
+
+assert( coroutine("memory_shared"):resume() == Shared, "memory_shared[a] test failed" )
+assert( Shared[2,number] == 1000000000, "memory_shared[b] test failed" )
+
 I = 0
 function void repeat_name(){
-    Co = coroutine("stack_overflow")
+    Co = coroutine("repeat_name")
     I++
     if(I==39){ error("cool error") }
     Co:resume()
 }
 
+print(try("repeat_name")[2,string])
 assert( try("repeat_name")[2,string]=="Coroutine Error: Coroutine stack overflow", "repeat_name test failed" )
 
 

--- a/lua/entities/gmod_wire_expression2/core/custom/Tests/Coroutines.txt
+++ b/lua/entities/gmod_wire_expression2/core/custom/Tests/Coroutines.txt
@@ -19,7 +19,7 @@
         Coroutines that last several ticks (Use https://github.com/Vurv78/VExtensions/discussions/29 instead.)
 ]#
 
-COROUTINE_STACK_MAX = 51
+COROUTINE_STACK_MAX = 5
 
 I = 0
 function void stack_overflow(){
@@ -33,8 +33,7 @@ assert(try("stack_overflow")[1,number]==0,"stack_overflow test failed")
 
 The_Table = table("br",2,3) # For some reason this can't be local
 function table return_table(){
-    print("Return table test!")
-    print("ret",The_Table[1,string])
+    assert(The_Table[1,string]=="br","return_table test failed[a]")
     The_Table[2,number] = 420
     return The_Table
 }
@@ -42,8 +41,7 @@ function table return_table(){
 # You can't equate the two tables themselves, because for now we copy the actual scopes instead of having
 # 'real' shared tables.
 
-assert(The_Table[1,string] == coroutine("return_table"):resume()[1,string], "return_table test failed")
-print(The_Table[2,number])
+assert(The_Table[1,string] == coroutine("return_table"):resume()[1,string], "return_table test failed[b]")
 
 The_Number = 12040124 # Same as L12
 function table pass_args(T:table){
@@ -66,12 +64,11 @@ I = 0
 function void repeat_name(){
     Co = coroutine("repeat_name")
     I++
-    if(I==39){ error("cool error") }
+    if(I==5){ error("cool error") }
     Co:resume()
 }
 
-print(try("repeat_name")[2,string])
-assert( try("repeat_name")[2,string]=="Coroutine Error: Coroutine stack overflow", "repeat_name test failed" )
+assert( try("repeat_name")[2,string]=="Coroutine Error: cool error", "repeat_name test failed" )
 
 
 print("All checks passed.")

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_vexdocs.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_vexdocs.lua
@@ -17,7 +17,7 @@ end
  / /  / // /_/ // // / / /
 /_/  /_/ \__,_//_//_/ /_/
 
- Random Misc. Functions that are cool like hiding other people's chat (probably doesn't work) and setting the ranger Filter.                    
+ Random Misc. Functions that are cool like hiding other people's chat (probably doesn't work) and setting the ranger Filter.
 ]]
 
 desc("rangerOffsetManual(vvr)","Returns a ranger, direct result from the util.TraceLine call with startpos, endpos and filter")
@@ -26,11 +26,11 @@ desc("canHideChatPly(e)","Returns whether you can hide a chats player, checking 
 desc("hideChatPly(en)","Hides the chat of the player given [e] with n as 1 or 0 for whether it should")
 
 --[[
-    ____                         ___
-   / __ \ __  __ ____   ___     |__ \
-  / /_/ // / / // __ \ / _ \    __/ /
- / _, _// /_/ // / / //  __/   / __/
-/_/ |_| \__,_//_/ /_/ \___/   /____/
+    ____              _________
+   / __ \__  ______  / ____/__ \
+  / /_/ / / / / __ \/ __/  __/ /
+ / _, _/ /_/ / / / / /___ / __/
+/_/ |_|\__,_/_/ /_/_____//____/
 
  Allows for calling user-defined functions dynamically at runtime (similar to callable strings),
     with ability to check for success - to know whether an error occurred (like Lua pcall),
@@ -150,6 +150,7 @@ desc("coroutineRunning()","Returns the current running coroutine for this E2, el
 desc("coroutineYield()","Makes the coroutine pause until it is resumed again. It will remember everything that is happening")
 desc("coroutineYield(t)","Makes the coroutine pause until it is resumed again. It will remember everything that is happening. Use this overload if you need to pass data back to the caller (main thread)")
 desc("coroutineWait(n)","Makes a coroutine wait for the given amount of seconds, in this time, it is yielded and cannot be resumed")
+desc("nocoroutine()","Returns an 'invalid' coroutine value")
 
 -- Metamethods
 desc("resume(xco:)","Resumes the coroutine (if it is suspended), or starts the coroutine if it hasn't been started yet")
@@ -190,7 +191,6 @@ desc("runOnE2CReload(n)","Makes your e2 chip run when any selected player's e2 c
 desc("e2CReloadClk()","Returns 1 or 0 for whether the e2 chip was ran by someone with your chip selected with the e2 controller right clicking")
 
 -- Information, like the trace info for when any reload/click/selected event is triggered.
-
 desc("lastE2CUser()","Returns the last user to trigger an e2c event. By clicking their mouse or by selecting your e2")
 desc("lastE2CRangerInfo()","Returns the ranger information of the last e2c event, so you can get the position of a left click event for example")
 

--- a/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
@@ -9,24 +9,24 @@
     Can't halt Lua's coroutines, so it is safe.
 ]]
 
--- Note that this code is really hacky.
--- Currently it only saves the e2's scope as it is going into the coroutine and syncs cpu data with the main thread as they're resumed.
+-- Shouldn't be hacky anymore. Behaves just like regular e2, and 'local' variables are useful as they are the only ones that persist in a thread now.
 
 -- Function localization (local lookup is faster).
-local coroutine = coroutine
-local coroutine_running, coroutine_create, coroutine_resume, coroutine_yield, coroutine_status, coroutine_wait = coroutine.running, coroutine.create, coroutine.resume, coroutine.yield, coroutine.status, coroutine.wait
-
-local table_copy,string_match = table.Copy,string.match
-local newE2Table, buildBody, throw, getE2UDF = vex.newE2Table, vex.buildBody, vex.throw, vex.getE2UDF
+local coroutine, coroutine_running, coroutine_create, coroutine_resume, coroutine_yield, coroutine_status, coroutine_wait = coroutine, coroutine.running, coroutine.create, coroutine.resume, coroutine.yield, coroutine.status, coroutine.wait
+local string, string_match, string_replace = string, string.match, string.Replace -- String Library
+local table, table_copy = table, table.Copy -- Table Library
+local newE2Table, buildBody, throw, getE2UDF = vex.newE2Table, vex.buildBody, vex.throw, vex.getE2UDF -- VExtensions Library
 
 vex.registerExtension("coroutines", false, "Allows E2s to use coroutines.")
 
 -- Coroutine Object handling
-
 registerType("coroutine", "xco", nil,
     nil,
     nil,
     function(ret)
+        -- For some reason we don't throw an error here.
+        -- See https://github.com/wiremod/wire/blob/501dd9875ab1f6db37a795e1f9a946d382db4f1f/lua/entities/gmod_wire_expression2/core/entity.lua#L10
+
         if not ret then return end
         if type(ret)~="thread" then throw("Return value is neither nil nor a coroutine, but a %s!",type(ret)) end
     end,
@@ -37,15 +37,11 @@ registerType("coroutine", "xco", nil,
 
 -- Initialize coroutines
 registerCallback("construct", function(self)
-    self.coroutines = {
-        stack_level = 0,
-        running = nil
-    }
+    self.coroutines = {}
 end)
 
-
 -- When the E2 is being cleaned up, delete all of the coroutines.
-registerCallback("destruct",function(self)
+registerCallback("destruct", function(self)
     self.coroutines = nil
 end)
 
@@ -73,20 +69,20 @@ end
 -- Resumes a coroutine made with expression2.
 local function e2coroutine_resume( self, thread, data )
     self.coroutines.running = thread
-    local co_success,resultORError = coroutine_resume(thread,data)
+    local co_success, result_or_error = coroutine_resume(thread, data)
     self.coroutines.running = nil
     if co_success then
         -- Could be done, could've successfully yielded.
-        return resultORError
+        return result_or_error
     else
         -- Error in coroutine runtime. Prefixes with "Coroutine Error: "
-        local err = resultORError
+        local err = result_or_error
         if err == "exit" then return end -- exit() or reset()
         if err == "perf" then return throw("tick quota exceeded") end
-        err = string_match(err,"entities/gmod_wire_expression2/core/core.lua:%d+: (.*)") or err
+        err = string_match(err, "^entities/gmod_wire_expression2/core/core.lua:%d+: (.*)$") or err
         -- Anti-recursion StartsWith check to see if the prefix was already applied inside another coroutine scope's error.
-        err = (not err:StartWith("Coroutine Error: ")) and "Coroutine Error: "..err or err
-        return throw(err)
+        err = (not err:StartWith("Coroutine Error: ")) and ("Coroutine Error: "..err) or err
+        return throw( string_replace(err, "%", "%%") ) -- People could error with an % in it and break patterns
     end
 end
 -- Returns the currently running e2 coroutine. (Doesn't return if a coroutine outside of e2 is running)
@@ -102,64 +98,53 @@ local function e2coroutine_reboot(self,thread,args)
 end
 
 local function getCoroutineUDF( self, func_name, has_args )
-    local e2func,_,returnType = getE2UDF(self,func_name,nil,has_args and "t" or "")
-    if not e2func then throw("Coroutine was called with undefined function [%s%s]",func_name,has_args and "(table)" or "(void)") end
-    if not (returnType == "" or returnType == "t") then throw("Coroutine's UDF [%s] must return either void or table",func_name) end
+    local e2func, _, returnType = getE2UDF(self, func_name, nil, has_args and "t" or "")
+    if not e2func then throw("Coroutine was called with undefined function [%s(%s)]", func_name, has_args and "table" or "") end
+    if not (returnType == "" or returnType == "t") then throw("Coroutine's UDF [%s] must return either void or table", func_name) end
     return e2func
 end
 
-local function assertRunning(self,co_yield)
+local function assertRunning(self, yielding)
     -- Attempt to yield across C-call boundary. Keyword is either 'yield' or 'wait'
     if not e2coroutine_running(self) then
-        throw("Attempted to %s coroutine without an e2 coroutine running.",yielding and "yield a" or "wait")
+        throw("Attempted to %s coroutine without an e2 coroutine running.", yielding and "yield a" or "wait")
     end
 end
 
-local table_copy = table.Copy
-local function parentTable(t,parent)
-    local stockpile = table_copy(parent)
-    return setmetatable(t,{
-        __index = function(t,k)
-            local ret = stockpile[k]
-            return ret~=nil and ret or parent[k]
-        end,
-        __newindex = function(t,k,v)
-            stockpile[k] = v
-            parent[k] = v
-        end
-    })
-end
-
-local function createCoroutine(self,e2_udf,argTable)
+local function createCoroutine(self, e2_udf, arg_table)
     -- Anti-coroutine creation infinite loop.
     local active_thread = e2coroutine_running(self)
+
+    local stack_level = 0
+    local thread_data = self.coroutines[active_thread]
     if active_thread then
-        self.coroutines.stack_level = self.coroutines.stack_level + 1
-        -- Anything higher than 15 starts to lag servers. 30+ Seems to already crash.
-        -- Maybe this new system is just a whole lot more intensive. Then again recurring 15 times is already useless.
-        if self.coroutines.stack_level >= 15 then return throw("Coroutine stack overflow") end
-    else
-        self.coroutines.stack_level = 0
+        thread_data[2] = thread_data[2] + 1
+        stack_level = thread_data[2]
+        -- Ok, we are back if not at a better level of cpu time with coroutines.
+        -- Still going to set it at 50 because e2 should be pretty slow in comparison to lua.
+        if stack_level >= 50 then return throw("Coroutine stack overflow") end
     end
 
-    local instance = setmetatable(table_copy(self),{
-        __index = self,
-        __newindex = self,
+    local instance = table_copy(self)
+    instance.GlobalScope = self.GlobalScope
+    instance.Scopes = self.Scopes
+    instance.coroutines = self.coroutines
+    instance.prf = nil
+
+    instance = setmetatable(instance, {
+        __index = function(_,k)
+            return self[k] or 0 -- This is fucking stupid, prf sometimes returns nil?
+            -- Breaks here: wire/lua/entities/gmod_wire_expression2/init.lua L175 ``if self.context.prfcount + self.context.prf - e2_softquota > e2_hardquota then ``
+        end,
+        __newindex = self
     })
 
-    rawset(instance,"GlobalScope",parentTable({},self.GlobalScope))
-    rawset(instance,"Scopes",parentTable({},self.Scopes))
-
-    rawset(instance,"coroutines",nil)
-    rawset(instance,"prf",nil)
-
-    --local instance = getCoroutineInstance(self)
     local thread = coroutine_create(function()
-        local ret = e2_udf(instance, argTable and buildBody({["t"]=argTable}) or nil)
+        local ret = e2_udf(instance, arg_table and buildBody({["t"]=arg_table}) or nil)
         self.coroutines[coroutine_running()] = nil
         return ret
     end)
-    self.coroutines[thread] = e2_udf
+    self.coroutines[thread] = {e2_udf, stack_level}
     return thread
 end
 
@@ -167,58 +152,58 @@ __e2setcost(20)
 
 e2function coroutine coroutine(string func_name)
     -- Coroutines can only return a table of data in order to keep type-safety.
-    local e2func = getCoroutineUDF(self,func_name)
-    return createCoroutine(self,e2func)
+    local e2func = getCoroutineUDF(self, func_name)
+    return createCoroutine(self, e2func)
 end
 
-e2function coroutine coroutine(string func_name,table args)
-    local e2func = getCoroutineUDF(self,func_name,true)
-    return createCoroutine(self,e2func,args)
+e2function coroutine coroutine(string func_name, table args)
+    local e2func = getCoroutineUDF(self, func_name, true)
+    return createCoroutine(self, e2func, args)
 end
 
 __e2setcost(5)
 
 e2function table coroutineYield()
-    assertRunning(self,true)
+    assertRunning(self, true)
     return coroutine_yield(self) or newE2Table()
 end
 
 e2function table coroutineYield(table data)
-    assertRunning(self,true)
-    return coroutine_yield(self,data) or newE2Table()
+    assertRunning(self, true)
+    return coroutine_yield(self, data) or newE2Table()
 end
 
 e2function table coroutine:yield()
-    if not this then return end
-    assertRunning(self,true)
+    if not this then return newE2Table() end
+    assertRunning(self, true)
     return coroutine_yield(self) or newE2Table()
 end
 
 e2function table coroutine:yield(table data)
     if not this then return newE2Table() end
-    assertRunning(self,true)
-    return coroutine_yield(self,data) or newE2Table()
+    assertRunning(self, true)
+    return coroutine_yield(self, data) or newE2Table()
 end
 
-e2function void coroutine:wait(n)
+e2function void coroutine:wait(seconds)
     if not this then return end
     assertRunning(self)
-    coroutine_wait(n)
+    coroutine_wait(seconds)
 end
 
-e2function void coroutineWait(n)
+e2function void coroutineWait(seconds)
     assertRunning(self)
-    coroutine_wait(n)
+    coroutine_wait(seconds)
 end
 
 e2function table coroutine:resume()
-    if not this then return end
-    return e2coroutine_resume(self,this) or newE2Table()
+    if not this then return newE2Table() end
+    return e2coroutine_resume(self, this) or newE2Table()
 end
 
 e2function table coroutine:resume(table data)
     if not this then return newE2Table() end
-    return e2coroutine_resume(self,this,data) or newE2Table()
+    return e2coroutine_resume(self, this, data) or newE2Table()
 end
 
 __e2setcost(3)
@@ -228,7 +213,7 @@ e2function string coroutine:status()
     return coroutine_status(this)
 end
 
--- Returns the actual thread being run. No need to return a number before since we added the if operator on coroutines.
+-- Returns the currently active E2 coroutine/thread (or nil if this is running on the main thread).
 e2function coroutine coroutineRunning()
     return e2coroutine_running(self)
 end
@@ -238,10 +223,16 @@ __e2setcost(15)
 -- Returns the coroutine as if it was just created, 'reboot'ing it.
 e2function coroutine coroutine:reboot()
     if not this then return end
-    return e2coroutine_reboot(self,this)
+    return e2coroutine_reboot(self, this)
 end
 
 e2function coroutine coroutine:reboot(table args)
     if not this then return end
-    return e2coroutine_reboot(self,this,args)
+    return e2coroutine_reboot(self, this, args)
+end
+
+__e2setcost(1)
+
+e2function coroutine nocoroutine()
+    return nil
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
@@ -119,8 +119,7 @@ local function createCoroutine(self, e2_udf, arg_table)
     local stack_level = 0
     local thread_data = self.coroutines[active_thread]
     if active_thread then
-        thread_data.stack_level = thread_data.stack_level + 1
-        stack_level = thread_data.stack_level
+        stack_level = thread_data.stack_level + 1
         -- Ok, we are back if not at a better level of cpu time with coroutines.
         -- Still going to set it at 50 because e2 should be pretty slow in comparison to lua.
         if stack_level >= CO_OVERFLOW then return throw("Coroutine stack overflow") end

--- a/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
@@ -14,7 +14,6 @@
 -- Function localization (local lookup is faster).
 local coroutine_running, coroutine_create, coroutine_resume, coroutine_yield, coroutine_status, coroutine_wait = coroutine.running, coroutine.create, coroutine.resume, coroutine.yield, coroutine.status, coroutine.wait
 local string_match, string_replace = string.match, string.Replace -- String Library
-local table_copy = table.Copy -- Table Library
 local newE2Table, buildBody, throw, getE2UDF = vex.newE2Table, vex.buildBody, vex.throw, vex.getE2UDF -- VExtensions Library
 
 -- Max coroutines to have at once in a chip. This is around 1-5 megabytes of coroutines in memory usage.
@@ -171,7 +170,6 @@ e2function coroutine coroutine(string func_name, table args)
 end
 
 __e2setcost(5)
-
 e2function table coroutineYield()
     assertRunning(self, true)
     return coroutine_yield() or newE2Table()

--- a/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/sv_coroutines.lua
@@ -12,9 +12,9 @@
 -- Shouldn't be hacky anymore. Behaves just like regular e2, and 'local' variables are useful as they are the only ones that persist in a thread now.
 
 -- Function localization (local lookup is faster).
-local coroutine, coroutine_running, coroutine_create, coroutine_resume, coroutine_yield, coroutine_status, coroutine_wait = coroutine, coroutine.running, coroutine.create, coroutine.resume, coroutine.yield, coroutine.status, coroutine.wait
-local string, string_match, string_replace = string, string.match, string.Replace -- String Library
-local table, table_copy = table, table.Copy -- Table Library
+local coroutine_running, coroutine_create, coroutine_resume, coroutine_yield, coroutine_status, coroutine_wait = coroutine.running, coroutine.create, coroutine.resume, coroutine.yield, coroutine.status, coroutine.wait
+local string_match, string_replace = string.match, string.Replace -- String Library
+local table_copy = table.Copy -- Table Library
 local newE2Table, buildBody, throw, getE2UDF = vex.newE2Table, vex.buildBody, vex.throw, vex.getE2UDF -- VExtensions Library
 
 vex.registerExtension("coroutines", false, "Allows E2s to use coroutines.")

--- a/lua/entities/gmod_wire_expression2/core/custom/sv_vex_main.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/sv_vex_main.lua
@@ -1,10 +1,10 @@
 --[[
-    __  ___        _      
-   /  |/  /____ _ (_)____ 
+    __  ___        _
+   /  |/  /____ _ (_)____
   / /|_/ // __ `// // __ \
  / /  / // /_/ // // / / /
-/_/  /_/ \__,_//_//_/ /_/ 
- Random Misc. Functions that are cool like hiding other people's chat (probably doesn't work) and setting the ranger Filter.                    
+/_/  /_/ \__,_//_//_/ /_/
+ Random Misc. Functions that are cool like hiding other people's chat (probably doesn't work) and setting the ranger Filter.
 ]]
 
 local table_insert, util_TraceLine, string_format = table.insert, util.TraceLine, string.format -- Gonna be using this a lot


### PR DESCRIPTION
It's finally here, aggghhh.. Coroutines now properly share memory with the main thread while maintaining the memory they had at the beginning of their scope. 

We need to test the shit out of this so that we make sure we don't have to deal with this anymore..

Making a PR because I noticed some inconsistencies. This should fix #18 and CoroutineCore :tm: should really be a final product. Unless we want to add more bloat non-lua functions like xco:isDead()

https://github.com/Vurv78/VExtensions/blob/master/lua/entities/gmod_wire_expression2/core/custom/Tests/Coroutines.txt
``pass_args`` and ``return_table`` fail. Not sure why when the table is passed into it and in other e2 chips that take and return args it works fine. Every other test is fine, and https://github.com/Vurv78/VExtensions/discussions/29 worked as expected though.

Also we need to make sure that we can't demolish server cpu with this, since now only prf (ops) is shared between chips since I kind of realized that the other variables don't need to be inherited, because the coroutine's cpu time will count toward the main thread's cpu time.